### PR TITLE
Add human-readable formatting for notification values

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -77,7 +77,7 @@ templates:
     🔥 {{ .State }} {{ .AlertName }}@{{ .Hostname }} 🔥
     {{ .Time.Format "2006-01-02 15:04:05 MST" }}
 
-    current {{ .MetricName }} {{ printf "%.2f" .MetricValue }} {{ .Condition }} {{ .ThresholdValue }}
+    current {{ .MetricName }} {{ .FormattedMetricValue }} {{ .Condition }} {{ .FormattedThresholdValue }}
     {{if .Aggregation}}{{.Aggregation}}{{end}}{{if .DurationString}}({{.DurationString}}){{end}}
 
   alert_resolved: |

--- a/internal/alerter/alerter.go
+++ b/internal/alerter/alerter.go
@@ -159,6 +159,9 @@ func (a *Alerter) sendNotificationsForRule(event AlertEvent) {
 			Time:           event.Timestamp,
 			DurationString: event.Rule.DurationStr,
 			Aggregation:    event.Rule.Aggregation,
+			// Human-readable formatted values
+			FormattedMetricValue:    notifier.FormatValue(event.Rule.Metric, event.MetricValue),
+			FormattedThresholdValue: notifier.FormatValue(event.Rule.Metric, event.Rule.Threshold),
 		}
 
 		err := notifierInstance.Send(data, a.templates)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,7 +157,7 @@ func LoadConfig(filePath string) (*Config, error) {
 
 	// Default templates
 	if cfg.Templates.AlertFired == "" {
-		cfg.Templates.AlertFired = `ALERT FIRED: {{.AlertName}} on {{.Hostname}}. Metric: {{.MetricName}} {{.Condition}} {{.ThresholdValue}} (Current: {{printf "%.2f" .MetricValue}}). Time: {{.Time.Format "2006-01-02 15:04:05"}}`
+		cfg.Templates.AlertFired = `ALERT FIRED: {{.AlertName}} on {{.Hostname}}. Metric: {{.MetricName}} {{.Condition}} {{.FormattedThresholdValue}} (Current: {{.FormattedMetricValue}}). Time: {{.Time.Format "2006-01-02 15:04:05"}}`
 	}
 	if cfg.Templates.AlertResolved == "" {
 		cfg.Templates.AlertResolved = `ALERT RESOLVED: {{.AlertName}} on {{.Hostname}}. Time: {{.Time.Format "2006-01-02 15:04:05"}}`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -90,7 +90,7 @@ notification_channels: []
 				Alerts:               []AlertRuleConfig{},
 				NotificationChannels: []NotificationChannelConfig{},
 				Templates: TemplateConfig{
-					AlertFired:    `ALERT FIRED: {{.AlertName}} on {{.Hostname}}. Metric: {{.MetricName}} {{.Condition}} {{.ThresholdValue}} (Current: {{printf "%.2f" .MetricValue}}). Time: {{.Time.Format "2006-01-02 15:04:05"}}`,
+					AlertFired:    `ALERT FIRED: {{.AlertName}} on {{.Hostname}}. Metric: {{.MetricName}} {{.Condition}} {{.FormattedThresholdValue}} (Current: {{.FormattedMetricValue}}). Time: {{.Time.Format "2006-01-02 15:04:05"}}`,
 					AlertResolved: `ALERT RESOLVED: {{.AlertName}} on {{.Hostname}}. Time: {{.Time.Format "2006-01-02 15:04:05"}}`,
 				},
 			},


### PR DESCRIPTION
## Summary
- Adds automatic formatting of metric values in alert notifications based on metric type
- Byte rate metrics (*_bytes_ps) are formatted as B/s, KB/s, MB/s, or GB/s
- Percentage metrics (*_percent_*) are formatted with % suffix
- Raw values remain accessible for backward compatibility

**Before:**
```
current net_sent_bytes_ps 551052824.82 > 5.24288e+08
```

**After:**
```
current net_sent_bytes_ps 525.5 MB/s > 500.0 MB/s
```

## Test plan
- [x] Unit tests for `FormatValue`, `formatBytesPerSecond`, and `formatPercent` functions
- [x] All existing tests pass
- [x] Build succeeds
- [x] Manual testing with actual alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)